### PR TITLE
Improve cloning and move generation

### DIFF
--- a/src/game/node.py
+++ b/src/game/node.py
@@ -13,14 +13,24 @@ from src.settings import BOARD_LENGTH
 
 
 class Node:
+    __slots__ = (
+        "state",
+        "move",
+        "parent",
+        "children",
+        "total_reward",
+        "n_visit",
+        "heuristic",
+        "_lock",
+    )
+
     state: GameState
     move: tuple[int, int]
-    parent: Node | None
-    children: list[Node]
+    parent: "Node | None"
+    children: list["Node"]
     total_reward: float
     n_visit: int
     heuristic: float
-    thread_safe: bool
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- optimize `GameState` by switching to a `dataclass` with `slots`
- remove costly `copy.deepcopy` in `clone`
- simplify `legal_moves` loop to avoid building sets
- add `__slots__` to `Node` to reduce memory overhead

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `make help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6888fc6553d8832f90a86ce28e664d3e