### PR TITLE
Improve rollout move selection

### DIFF
--- a/src/game/node.py
+++ b/src/game/node.py
@@ -13,14 +13,24 @@ from src.settings import BOARD_LENGTH
 
 
 class Node:
+    __slots__ = (
+        "state",
+        "move",
+        "parent",
+        "children",
+        "total_reward",
+        "n_visit",
+        "heuristic",
+        "_lock",
+    )
+
     state: GameState
     move: tuple[int, int]
-    parent: Node | None
-    children: list[Node]
+    parent: "Node | None"
+    children: list["Node"]
     total_reward: float
     n_visit: int
     heuristic: float
-    thread_safe: bool
 
     def __init__(
         self,

--- a/src/settings.py
+++ b/src/settings.py
@@ -3,4 +3,5 @@ N_ITERATION = 1500
 TIME_LIMIT = 1
 N_ROLLOUT = 5  # Number of rollouts (playouts) to average in a single simulation
 MAX_DEPTH = 20  # Maximum number of moves per rollout (rollout depth limit)
+ROLLOUT_SAMPLE_SIZE = 5  # Number of candidate moves evaluated per rollout step
 DEBUG_MODE = False


### PR DESCRIPTION
## Summary
- add `ROLLOUT_SAMPLE_SIZE` setting
- use heuristic-guided move selection during rollouts

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `make help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6888fc6553d8832f90a86ce28e664d3e